### PR TITLE
Ensure import for ToFloat and Remainder.

### DIFF
--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -84,6 +84,12 @@ let pervasive_imports =
         ConcreteImport (make_ident "toInt64", None);
         ConcreteImport (make_ident "ToIndex", None);
         ConcreteImport (make_ident "toIndex", None);
+        ConcreteImport (make_ident "ToFloat32", None);
+        ConcreteImport (make_ident "toFloat32", None);
+        ConcreteImport (make_ident "ToFloat64", None);
+        ConcreteImport (make_ident "toFloat64", None);
+        ConcreteImport (make_ident "Remainder", None);
+        ConcreteImport (make_ident "rem", None);
       ]
     )
 


### PR DESCRIPTION
Discussion in Discord explored that `toFloat64(Int32)` did not appear to be working properly. Found that although `ToFloat32`, `ToFloat64`, and `Remainder` were implemented in Pervasive, they were not recognized in applications. Verified the rest of the compiler pipeline and also verified that a test application using `toFloat64(Int32)` worked properly after applying this change.